### PR TITLE
SO_PEERCRED is Linux only

### DIFF
--- a/unixcreds_linux.go
+++ b/unixcreds_linux.go
@@ -1,5 +1,3 @@
-// +build linux freebsd solaris
-
 package ttrpc
 
 import (


### PR DESCRIPTION
BSD does have LOCAL_PEERCRED but x/sys.unix does not yet have support for it.
I will add support and do a proper fix later.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>