### PR TITLE
ttrpc: return ErrClosed when client is shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ErrServerClosed = errors.New("ttrpc: server close")
+	ErrServerClosed = errors.New("ttrpc: server closed")
 )
 
 type Server struct {

--- a/server_test.go
+++ b/server_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -220,7 +221,7 @@ func TestServerShutdown(t *testing.T) {
 	<-shutdownFinished
 
 	for i := 0; i < ncalls; i++ {
-		if err := <-callErrs; err != nil {
+		if err := <-callErrs; err != nil && err != ErrClosed {
 			t.Fatal(err)
 		}
 	}
@@ -329,6 +330,8 @@ func TestClientEOF(t *testing.T) {
 	// server shutdown, but we still make a call.
 	if err := client.Call(ctx, serviceName, "Test", tp, tp); err == nil {
 		t.Fatalf("expected error when calling against shutdown server")
+	} else if errors.Cause(err) != ErrClosed {
+		t.Fatalf("expected to have a cause of ErrClosed, got %v", errors.Cause(err))
 	}
 }
 


### PR DESCRIPTION
To gracefully handle scenarios where the connection is closed or the
client is closed, we now set the final error to be `ErrClosed`. Callers
can resolve it through using `errors.Cause` to detect this condition.

Signed-off-by: Stephen J Day <stephen.day@docker.com>
  
Closes #16