### PR TITLE
ttrpc: return correct error on (*Client).Close

### DIFF
--- a/client.go
+++ b/client.go
@@ -199,7 +199,7 @@ func (c *Client) run() {
 			}
 			// broadcast the shutdown error to the remaining waiters.
 			for _, waiter := range waiters {
-				waiter.errs <- shutdownErr
+				waiter.errs <- c.err
 			}
 			return
 		}


### PR DESCRIPTION
Because `shutdownErr` will likely be `nil` in the close select branch,
returning it to waiters will result in the waiting `(*Client).Call`
returning `(nil, nil)`. This should take whatever is set for the client
as the exit condition, which is likely to be `ErrClosed`.

Signed-off-by: Stephen J Day <stephen.day@docker.com>